### PR TITLE
fix(.devops): roll back to previous working template version

### DIFF
--- a/.devops/azure-pipelines.yml
+++ b/.devops/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
     - repository: templates
       type: github
       name: ExtendRealityLtd/DevOps
-      ref: refs/tags/v3.12.2
+      ref: refs/tags/v3.12.1
       endpoint: ExtendRealityLtd
 
 variables:


### PR DESCRIPTION
The latest template version does not work and whilst the previous
template version doesn't work, this is due to a problem outside
of our control and should be fixed in due course.