### PR TITLE
fix(package.json): add missing object follower dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "1.12.0"
+        "io.extendreality.zinnia.unity": "1.12.0",
+        "io.extendreality.tilia.mutators.objectfollower.unity": "1.0.6"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The ColliderFollower prefab relies on the Tilia ObjectFollower prefab
as an ObjectFollower is used to provide the following mechanism.

This means the other package is required for this dependency to work.