### PR TITLE
refactor(prefabs): update nested follow prefab to be rigidbody follower

### DIFF
--- a/Runtime/Prefabs/Trackers.ColliderFollower.prefab
+++ b/Runtime/Prefabs/Trackers.ColliderFollower.prefab
@@ -44,8 +44,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 25c79c0a1b4e65e41beb97b9f66a29fb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  source: {fileID: 0}
-  useLocal: 0
   Extracted:
     m_PersistentCalls:
       m_Calls:
@@ -62,6 +60,13 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: Zinnia.Data.Operation.Extraction.TransformVector3PropertyExtractor+UnityEvent,
       Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Failed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  source: {fileID: 0}
+  useLocal: 0
 --- !u!114 &9092021811401245231
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -92,7 +97,7 @@ GameObject:
   - component: {fileID: 2632195220641112780}
   - component: {fileID: 6434841534626989321}
   m_Layer: 0
-  m_Name: ColliderFollower
+  m_Name: Trackers.ColliderFollower
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -156,7 +161,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 6410866299087718415}
+  - {fileID: 4047302465864999380}
   - {fileID: 7246870332922131805}
   m_Father: {fileID: 2632195220641112780}
   m_RootOrder: 1
@@ -174,59 +179,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   facade: {fileID: 6434841534626989321}
-  objectFollower: {fileID: 6448605195277943161}
+  objectFollower: {fileID: 4153194663392602274}
   positionExtractor: {fileID: 7706563081135637935}
   colliderContainer: {fileID: 8972421161141143531}
---- !u!114 &4608236425198544497
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6404962417342613659}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 211d9aa971593cc43821fa228ec82c80, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  applyOffset: 1
-  Premodified:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  Modified:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  angularVelocityLimit: Infinity
-  maxDistanceDelta: 10
---- !u!114 &2209404458595471245
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6405003631763454975}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fbe23337e6e41bc449243b5624bf47ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  applyOffset: 1
-  Premodified:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  Modified:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Tracking.Follow.ObjectFollower+FollowEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  velocityLimit: Infinity
-  maxDistanceDelta: 10
 --- !u!1 &8972421161141143531
 GameObject:
   m_ObjectHideFlags: 0
@@ -288,101 +243,96 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
---- !u!1001 &6405913350800124119
+--- !u!1001 &9220409073195838355
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 6053823821777842292}
     m_Modifications:
-    - target: {fileID: 1068226196861958, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5174005062009659033, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_Name
-      value: ObjectFollower
+      value: Mutators.RigidbodyFollower
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+    - target: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1392910959889882537, guid: 9aa99d00578590e45a52faa205a1014a,
+    - target: {fileID: 6096348427360433974, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
         type: 3}
       propertyPath: elements.Array.size
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1392910959889882537, guid: 9aa99d00578590e45a52faa205a1014a,
+    - target: {fileID: 6096348427360433974, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
         type: 3}
       propertyPath: elements.Array.data[0]
       value: 
       objectReference: {fileID: 8972421161141143531}
-    - target: {fileID: 114374749712010186, guid: 9aa99d00578590e45a52faa205a1014a,
-        type: 3}
-      propertyPath: rotationModifier
-      value: 
-      objectReference: {fileID: 4608236425198544497}
-    - target: {fileID: 114374749712010186, guid: 9aa99d00578590e45a52faa205a1014a,
-        type: 3}
-      propertyPath: positionModifier
-      value: 
-      objectReference: {fileID: 2209404458595471245}
-    - target: {fileID: 114265967538520616, guid: 9aa99d00578590e45a52faa205a1014a,
-        type: 3}
-      propertyPath: processMoment
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 114065135811493534, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
-    - {fileID: 114338087786370432, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
-  m_SourcePrefab: {fileID: 100100000, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
---- !u!4 &6410866299087718415 stripped
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5d59f26fca26fd746acfe45b38eb4fa5, type: 3}
+--- !u!4 &4047302465864999380 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a,
+  m_CorrespondingSourceObject: {fileID: 5179017617822861895, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
     type: 3}
-  m_PrefabInstance: {fileID: 6405913350800124119}
+  m_PrefabInstance: {fileID: 9220409073195838355}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &6448605195277943161 stripped
+--- !u!114 &4153194663392602274 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 114960550120155566, guid: 9aa99d00578590e45a52faa205a1014a,
+  m_CorrespondingSourceObject: {fileID: 5068350279941882673, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
     type: 3}
-  m_PrefabInstance: {fileID: 6405913350800124119}
+  m_PrefabInstance: {fileID: 9220409073195838355}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -390,15 +340,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36b5781728bc3ef47af5d7aca57b0e57, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &6404962417342613659 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1300870921756748, guid: 9aa99d00578590e45a52faa205a1014a,
-    type: 3}
-  m_PrefabInstance: {fileID: 6405913350800124119}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &6405003631763454975 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1482822829691688, guid: 9aa99d00578590e45a52faa205a1014a,
-    type: 3}
-  m_PrefabInstance: {fileID: 6405913350800124119}
-  m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
The Collider Follower relies upon a nested follower to get the collider
to follow the source. This was previously a customised ObjectFollower
that made it follow the rigidbody velocities. The ObjectFollower
package now contains a RigidbodyFollower prefab that does exactly this
so the nested prefab within the ColliderFollower has been updated to
use this new prefab instead of customising the old one.

This change may break functionality for any customisation of the
internal nested prefab and any customisations will need reapplying.