### PR TITLE
feat(Malimbe): remove malimbe dependency

### DIFF
--- a/Documentation/API/ColliderFollowerFacade.md
+++ b/Documentation/API/ColliderFollowerFacade.md
@@ -11,6 +11,7 @@ The public interface for the ColliderFollower prefab.
   * [Configuration]
   * [Source]
 * [Methods]
+  * [ClearSource()]
   * [OnAfterSourceChange()]
   * [SnapToSource()]
 
@@ -55,6 +56,16 @@ public GameObject Source { get; set; }
 
 ### Methods
 
+#### ClearSource()
+
+Clears [Source].
+
+##### Declaration
+
+```
+public virtual void ClearSource()
+```
+
 #### OnAfterSourceChange()
 
 Called after [Source] has been changed.
@@ -78,6 +89,7 @@ public virtual void SnapToSource()
 [Tilia.Trackers.ColliderFollower]: README.md
 [ColliderFollowerConfigurator]: ColliderFollowerConfigurator.md
 [Source]: ColliderFollowerFacade.md#Source
+[Source]: ColliderFollowerFacade.md#Source
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -85,5 +97,6 @@ public virtual void SnapToSource()
 [Configuration]: #Configuration
 [Source]: #Source
 [Methods]: #Methods
+[ClearSource()]: #ClearSource
 [OnAfterSourceChange()]: #OnAfterSourceChange
 [SnapToSource()]: #SnapToSource

--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<Weavers>
-  <Malimbe.FodyRunner>
-    <AssemblyNameRegex>^Tilia.Trackers.ColliderFollower</AssemblyNameRegex>
-  </Malimbe.FodyRunner>
-</Weavers>

--- a/FodyWeavers.xml.meta
+++ b/FodyWeavers.xml.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 90cf444332b7aa747b7f4be8ac15d860
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/ColliderFollowerConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/ColliderFollowerConfigurator.cs
@@ -1,7 +1,5 @@
 ﻿namespace Tilia.Trackers.ColliderFollower
 {
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Operation.Extraction;
@@ -14,33 +12,83 @@
     public class ColliderFollowerConfigurator : MonoBehaviour
     {
         #region Facade Settings
+        [Header("Facade Settings")]
+        [Tooltip("The public interface facade.")]
+        [SerializeField]
+        [Restricted]
+        private ColliderFollowerFacade facade;
         /// <summary>
         /// The public interface facade.
         /// </summary>
-        [Serialized]
-        [field: Header("Facade Settings"), DocumentedByXml, Restricted]
-        public ColliderFollowerFacade Facade { get; protected set; }
+        public ColliderFollowerFacade Facade
+        {
+            get
+            {
+                return facade;
+            }
+            protected set
+            {
+                facade = value;
+            }
+        }
         #endregion
 
         #region Reference Settings
+        [Header("Reference Settings")]
+        [Tooltip("The Zinnia.Tracking.Follow.ObjectFollower that performs the source follow.")]
+        [SerializeField]
+        [Restricted]
+        private ObjectFollower objectFollower;
         /// <summary>
         /// The <see cref="Zinnia.Tracking.Follow.ObjectFollower"/> that performs the source follow.
         /// </summary>
-        [Serialized]
-        [field: Header("Reference Settings"), DocumentedByXml, Restricted]
-        public ObjectFollower ObjectFollower { get; protected set; }
+        public ObjectFollower ObjectFollower
+        {
+            get
+            {
+                return objectFollower;
+            }
+            protected set
+            {
+                objectFollower = value;
+            }
+        }
+        [Tooltip("The TransformPositionExtractor that extracts the source position.")]
+        [SerializeField]
+        [Restricted]
+        private TransformPositionExtractor positionExtractor;
         /// <summary>
         /// The <see cref="TransformPositionExtractor"/> that extracts the source position.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml, Restricted]
-        public TransformPositionExtractor PositionExtractor { get; protected set; }
+        public TransformPositionExtractor PositionExtractor
+        {
+            get
+            {
+                return positionExtractor;
+            }
+            protected set
+            {
+                positionExtractor = value;
+            }
+        }
+        [Tooltip("The GameObject containing the collider.")]
+        [SerializeField]
+        [Restricted]
+        private GameObject colliderContainer;
         /// <summary>
         /// The <see cref="GameObject"/> containing the collider.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml, Restricted]
-        public GameObject ColliderContainer { get; protected set; }
+        public GameObject ColliderContainer
+        {
+            get
+            {
+                return colliderContainer;
+            }
+            protected set
+            {
+                colliderContainer = value;
+            }
+        }
         #endregion
 
         /// <summary>

--- a/Runtime/SharedResources/Scripts/ColliderFollowerFacade.cs
+++ b/Runtime/SharedResources/Scripts/ColliderFollowerFacade.cs
@@ -1,11 +1,7 @@
 ﻿namespace Tilia.Trackers.ColliderFollower
 {
-    using Malimbe.MemberChangeMethod;
-    using Malimbe.MemberClearanceMethod;
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
-    using Zinnia.Data.Attribute;
+    using Zinnia.Extension;
 
     /// <summary>
     /// The public interface for the ColliderFollower prefab.
@@ -13,22 +9,63 @@
     public class ColliderFollowerFacade : MonoBehaviour
     {
         #region Tracking Settings
+        [Header("Tracking Settings")]
+        [Tooltip("The source to track.")]
+        [SerializeField]
+        private GameObject source;
         /// <summary>
         /// The source to track.
         /// </summary>
-        [Serialized, Cleared]
-        [field: Header("Tracking Settings"), DocumentedByXml]
-        public GameObject Source { get; set; }
+        public GameObject Source
+        {
+            get
+            {
+                return source;
+            }
+            set
+            {
+                source = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterSourceChange();
+                }
+            }
+        }
         #endregion
 
         #region Reference Settings
+        [Header("Reference Settings")]
+        [Tooltip("The linked Internal Setup.")]
+        [SerializeField]
+        private ColliderFollowerConfigurator configuration;
         /// <summary>
         /// The linked Internal Setup.
         /// </summary>
-        [Serialized]
-        [field: Header("Reference Settings"), DocumentedByXml, Restricted]
-        public ColliderFollowerConfigurator Configuration { get; protected set; }
+        public ColliderFollowerConfigurator Configuration
+        {
+            get
+            {
+                return configuration;
+            }
+            protected set
+            {
+                configuration = value;
+            }
+        }
         #endregion
+
+        /// <summary>
+        /// Clears <see cref="Source"/>.
+        /// </summary>
+        public virtual void ClearSource()
+        {
+            if (!this.IsValidState())
+            {
+                return;
+            }
+
+            Source = default;
+        }
 
         /// <summary>
         /// Snaps the tracked collider directly to the source current position.
@@ -41,7 +78,6 @@
         /// <summary>
         /// Called after <see cref="Source"/> has been changed.
         /// </summary>
-        [CalledAfterChangeOf(nameof(Source))]
         protected virtual void OnAfterSourceChange()
         {
             Configuration.SetSource(Source);

--- a/Runtime/Tilia.Trackers.ColliderFollower.Unity.Runtime.asmdef
+++ b/Runtime/Tilia.Trackers.ColliderFollower.Unity.Runtime.asmdef
@@ -8,13 +8,7 @@
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "Malimbe.PropertySerializationAttribute.dll",
-        "Malimbe.XmlDocumentationAttribute.dll",
-        "Malimbe.MemberChangeMethod.dll",
-        "Malimbe.MemberClearanceMethod.dll",
-        "Malimbe.FodyRunner.UnityIntegration.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": []
 }


### PR DESCRIPTION
BREAKING CHANGE: This removes the last remaining elements of
Malimbe and whilst it does not cause any breaking changes within
this package, it removes Malimbe as a dependency which other projects
that rely on this package may piggy back off this Malimbe dependency
so it will break any project like that.

All of the previous functionality from Malimbe has been replicated in
standard code without the need for it to be weaved by the Malimbe
helper tags.