### PR TITLE
feat(prefab): add collider follower tag for easy collider recognition

### DIFF
--- a/Documentation/API/ColliderFollowerTag.md
+++ b/Documentation/API/ColliderFollowerTag.md
@@ -1,0 +1,18 @@
+# Class ColliderFollowerTag
+
+Provides the ability to identify a collider follower Rigidbody component.
+
+##### Inheritance
+
+* System.Object
+* ColliderFollowerTag
+
+###### **Namespace**: [Tilia.Trackers.ColliderFollower]
+
+##### Syntax
+
+```
+public class ColliderFollowerTag : MonoBehaviour
+```
+
+[Tilia.Trackers.ColliderFollower]: README.md

--- a/Documentation/API/ColliderFollowerTag.md.meta
+++ b/Documentation/API/ColliderFollowerTag.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 539b1d79325d3154ca46f8d1b5e9dd40
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/README.md
+++ b/Documentation/API/README.md
@@ -10,5 +10,10 @@ Sets up the ColliderFollower prefab based on the provided settings and implement
 
 The public interface for the ColliderFollower prefab.
 
+#### [ColliderFollowerTag]
+
+Provides the ability to identify a collider follower Rigidbody component.
+
 [ColliderFollowerConfigurator]: ColliderFollowerConfigurator.md
 [ColliderFollowerFacade]: ColliderFollowerFacade.md
+[ColliderFollowerTag]: ColliderFollowerTag.md

--- a/Runtime/Prefabs/Trackers.ColliderFollower.prefab
+++ b/Runtime/Prefabs/Trackers.ColliderFollower.prefab
@@ -280,6 +280,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8674484898788623824}
+  - component: {fileID: 2562326874711141406}
   - component: {fileID: 440832740436235133}
   - component: {fileID: 4915136484543182852}
   m_Layer: 0
@@ -303,6 +304,18 @@ Transform:
   m_Father: {fileID: 2632195220641112780}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2562326874711141406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8972421161141143531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f78abbcbc9005e4984655c701e49b74, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!54 &440832740436235133
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Runtime/SharedResources/Scripts/ColliderFollowerTag.cs
+++ b/Runtime/SharedResources/Scripts/ColliderFollowerTag.cs
@@ -1,0 +1,9 @@
+﻿namespace Tilia.Trackers.ColliderFollower
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Provides the ability to identify a collider follower <see cref="Rigidbody"/> component.
+    /// </summary>
+    public class ColliderFollowerTag : MonoBehaviour { }
+}

--- a/Runtime/SharedResources/Scripts/ColliderFollowerTag.cs.meta
+++ b/Runtime/SharedResources/Scripts/ColliderFollowerTag.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f78abbcbc9005e4984655c701e49b74
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The new ColliderFollowerTag has been added to the rigidbody gameobject so it is easy to identify all collider followers.