### PR TITLE
feat(Facade): add linked follow tracking container reference

### DIFF
--- a/Runtime/Prefabs/Trackers.ColliderFollower.prefab
+++ b/Runtime/Prefabs/Trackers.ColliderFollower.prefab
@@ -134,6 +134,10 @@ MonoBehaviour:
   source: {fileID: 0}
   snapOnEnable: 0
   configuration: {fileID: 7631982828909951989}
+  linkedFollowTrackingContainer:
+    linkedObject: {fileID: 4052246705190749232}
+    linkText: Show Follow Tracking Container
+    isActive: 1
 --- !u!1 &5673201884694615319
 GameObject:
   m_ObjectHideFlags: 0
@@ -442,3 +446,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36b5781728bc3ef47af5d7aca57b0e57, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &4052246705190749232 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5172667690854395811, guid: 5d59f26fca26fd746acfe45b38eb4fa5,
+    type: 3}
+  m_PrefabInstance: {fileID: 9220409073195838355}
+  m_PrefabAsset: {fileID: 0}

--- a/Runtime/SharedResources/Scripts/ColliderFollowerFacade.cs
+++ b/Runtime/SharedResources/Scripts/ColliderFollowerFacade.cs
@@ -1,6 +1,7 @@
 ﻿namespace Tilia.Trackers.ColliderFollower
 {
     using UnityEngine;
+    using Zinnia.Data.Type;
     using Zinnia.Extension;
 
     /// <summary>
@@ -67,6 +68,23 @@
             protected set
             {
                 configuration = value;
+            }
+        }
+        [Tooltip("The GameObject reference for the nested Follow Tracking Container.")]
+        [SerializeField]
+        private ObjectReference linkedFollowTrackingContainer;
+        /// <summary>
+        /// The <see cref="GameObject"/> reference for the nested Follow Tracking Container.
+        /// </summary>
+        public ObjectReference LinkedFollowTrackingContainer
+        {
+            get
+            {
+                return linkedFollowTrackingContainer;
+            }
+            protected set
+            {
+                linkedFollowTrackingContainer = value;
             }
         }
         #endregion


### PR DESCRIPTION
A new reference to the internal follow tracking container has been added so it is easier to get to the internal logic.